### PR TITLE
Fix temperature measurement

### DIFF
--- a/opentherm-ha/opentherm-ha.ino
+++ b/opentherm-ha/opentherm-ha.ino
@@ -109,6 +109,7 @@ void updateData()
 
     unsigned long now = millis();
 
+    t = getTemp();
     new_ts = millis();
     dt = (new_ts - ts) / 1000.0;
     ts = new_ts;


### PR DESCRIPTION
The temperature was no longer read from the onboard temperature sensor. I reinstated it inside the successful OpenTherm call.

closes #4 